### PR TITLE
Update usage guide for easy usage within Symfony

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -19,6 +19,9 @@ $formFactory = Forms::createFormFactoryBuilder()
     ->addExtension(new OrderedExtension())
     ->getFormFactory();
 
+// To inherit the default symfony extensions, add the extension "form.extension"
+// eg. ->addExtension($this->get('form.extension'))
+
 $form = $formFactory->createBuilder()
     ->add('dueDate', 'date')
     ->add('task', 'text', array('position' => 'first'))


### PR DESCRIPTION
Adding the form.extension Extension to the new formfactorybuilder replicates the setup for the form.factory service. 

It was something I would have really appreciated in the doco.